### PR TITLE
Fixed typo in instructions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,7 +478,7 @@ function hasLooped(sound) {
 			<ul style="font-size:75%; line-height: 1.1;">
 				<li> <em>Boots</em> are worth 5 points each.</li>
 				<li> <em>Fish</em> are worth from 40 (slowest) to 140 (fastest) point each depending on speed.</li>
-				<li> If a <em>Boot</em> hits the sea floor, you loose all the points you have accumulated.</li>
+				<li> If a <em>Boot</em> hits the sea floor, you lose all the points you have accumulated.</li>
 			</ul>
 
 			Controls:


### PR DESCRIPTION
Fixed typo: `loose` -> `lose`